### PR TITLE
Fix manage.py ldapsync command (fixes #17)

### DIFF
--- a/dreamjub/models.py
+++ b/dreamjub/models.py
@@ -221,7 +221,7 @@ class Student(models.Model):
         users = user.parse_all_users(username, password)
 
         # if we get no users, there was     an error in authentication
-        if users in None:
+        if users is None:
             return False
 
         # mark all of the current ones inactive


### PR DESCRIPTION
A regression was found that prevented the ldapsync command to execute
properly. This PR corrects the typo that caused the problem.