### PR TITLE
Ensure that LDAP attributes are lists

### DIFF
--- a/jacobsdata/parsing/course_components/component.py
+++ b/jacobsdata/parsing/course_components/component.py
@@ -18,15 +18,24 @@ class CourseParsingComponent(object):
                       single: bool = True) -> typing.Any:
         """ Gets an attribute from an LDAP object representing a group. """
 
+        # read out the course attribute
         try:
             attlist = course['attributes'][attribute]
         except KeyError:
             attlist = []
+
+        # make sure that we actually got a list and not a single value
+        if isinstance(attlist, str):
+            attlist = [attlist]
+
+        # if we want a single value, extract it.
         if single:
             if len(attlist) > 0:
                 return attlist[0]
             else:
                 return fallback
+
+        # else return the normal value
         else:
             return attlist
 

--- a/jacobsdata/parsing/user_components/component.py
+++ b/jacobsdata/parsing/user_components/component.py
@@ -18,15 +18,24 @@ class UserParsingComponent(object):
                       single: bool = True) -> typing.Any:
         """ Gets an attribute from an LDAP object representing a group. """
 
+        # read out the user attribute
         try:
             attlist = user['attributes'][attribute]
         except KeyError:
             attlist = []
+
+        # make sure that we actually got a list and not a single value
+        if isinstance(attlist, str):
+            attlist = [attlist]
+
+        # if we want a single value, extract it.
         if single:
             if len(attlist) > 0:
                 return attlist[0]
             else:
                 return fallback
+
+        # else return the normal value
         else:
             return attlist
 


### PR DESCRIPTION
On the production server importing students and courses was not working
properly. The regression was caused by not checking that attributes read
from LDAP were a list. This PR fixes the problem by turning them into
a list explicitly.