### PR TITLE
Add more operators to the Query Language

### DIFF
--- a/api/filters/builder.py
+++ b/api/filters/builder.py
@@ -1,3 +1,5 @@
+import functools
+
 from . import operators as ops
 """This module holds QBuilder."""
 
@@ -21,6 +23,9 @@ class QBuilder(object):
 
         elif obj_type == ops.UN_TYPE:
             return self._generate_unary(filter_obj)
+
+        elif obj_type == ops.COMPOUND_TYPE:
+            return self._generate_compound(filter_obj)
 
         elif obj_type in [ops.IDENTITY_TYPE, ops.STRING_TYPE]:
             return self._generate_literal(filter_obj)
@@ -56,6 +61,18 @@ class QBuilder(object):
             raise ValueError("Unknown unary operator: " + filter_type)
 
         return op(self.translate(argument))
+
+    def _generate_compound(self, filter_obj):
+        """Compound expressions are implicitly converted into a series of
+        AND connected clauses."""
+        try:
+            body = filter_obj['body']
+        except KeyError as e:
+            raise ValueError("Compound is missing: " + str(e))
+
+        clauses = [self.translate(part) for part in body]
+
+        return functools.reduce(ops.and_fn, clauses)
 
     def _generate_literal(self, literal):
         try:

--- a/api/filters/extended.py
+++ b/api/filters/extended.py
@@ -10,6 +10,32 @@ class TLFilter(filters.BaseFilterBackend):
 
     def filter_queryset(self, request, queryset, view):
         parser = PreJsPy.PreJsPy()
+
+        # Do not use the tertiary operator -- we do not need it
+        parser.setTertiaryOperatorEnabled(False)
+
+        # Set up the unary operators properly
+        parser.setUnaryOperators([
+            'not', '!', '~'
+        ])
+
+        parser.setBinaryOperators({
+            # LOGICAL CONNECTIVES
+            'and': 1, '&': 1, '&&': 1, '*': 1,
+            'or': 1, '|': 1, '||': 1, '+': 1,
+            'nand': 1, '!&': 1,
+            'xor': 1, '^': 1,
+
+            # Filters
+            'equals': 2, ':': 2, '=': 2, '==': 2, '===': 2,
+            'less than': 2, '<': 2,
+            'less than or equal': 2, '<=': 2, '=<': 2,
+            'greater than': 2, '>': 2,
+            'greater than or equal': 2, '>=': 2, '=>': 2,
+            'contains': 2, '::': 2,
+            'matches': 2, 'unicorn': 2, '@': 2,
+        })
+
         builder = qb.QBuilder()
 
         query_str = request.GET.get('tl', default=None)

--- a/api/filters/operators.py
+++ b/api/filters/operators.py
@@ -8,7 +8,6 @@ definitions used in QBuilder."""
 def not_impl(*args):
     raise NotImplementedError
 
-
 # Binary logic expressions
 and_fn = operator.and_
 or_fn = operator.or_
@@ -30,7 +29,6 @@ def q_lambda(dj_filter="exact"):
 
 def not_eq(x, y):
     return not_fn(q_lambda()(x, y))
-
 
 UNARY_OPS = {
     'not': not_fn,

--- a/api/filters/operators.py
+++ b/api/filters/operators.py
@@ -54,6 +54,8 @@ BIN_OPS = {
     '==': q_lambda(),
     '===': q_lambda(),
 
+    '!=': not_eq,
+
     'less than': q_lambda('lt'),
     '<': q_lambda('lt'),
 

--- a/api/filters/operators.py
+++ b/api/filters/operators.py
@@ -8,6 +8,7 @@ definitions used in QBuilder."""
 def not_impl(*args):
     raise NotImplementedError
 
+
 # Binary logic expressions
 and_fn = operator.and_
 or_fn = operator.or_
@@ -18,6 +19,10 @@ def xor_fn(x, y):
     return or_fn(and_fn(not_fn(x), y), and_fn(x, not_fn(y)))
 
 
+def nand_fn(x, y):
+    return not_fn(and_fn(x, y))
+
+
 # Django filters
 def q_lambda(dj_filter="exact"):
     return lambda x, y: models.Q(**{x + '__' + dj_filter: y})
@@ -26,38 +31,54 @@ def q_lambda(dj_filter="exact"):
 def not_eq(x, y):
     return not_fn(q_lambda()(x, y))
 
+
 UNARY_OPS = {
-    '-': not_impl,
+    'not': not_fn,
     '!': not_fn,
-    '~': not_fn,
-    '+': not_impl
+    '~': not_fn
 }
 
 BIN_OPS = {
-    '||': or_fn,
-    '&&': and_fn,
-    '|': or_fn,
-    '^': xor_fn,
-    '&': and_fn,
-    '==': q_lambda(),
-    '!=': not_eq,
-    '===': q_lambda(),
-    '!==': not_eq,
-    '<': q_lambda('lt'),
-    '>': q_lambda('gt'),
-    '<=': q_lambda('lte'),
-    '>=': q_lambda('gte'),
+    # LOGICAL CONNECTIVES
+    'and': and_fn, '&': and_fn, '&&': and_fn, '*': and_fn,
 
-    '<<': not_impl,
-    '>>': not_impl,
-    '>>>': not_impl,
-    '+': not_impl,
-    '-': not_impl,
-    '*': not_impl,
-    '/': not_impl,
-    '%': not_impl
+    'or': or_fn, '|': or_fn, '||': or_fn, '+': or_fn,
+
+    'nand': nand_fn, '!&': nand_fn,
+
+    'xor': xor_fn, '^': xor_fn,
+
+    # FILTERS
+    'equals': q_lambda(),
+    'eq': q_lambda(),
+    ':': q_lambda(),
+    '=': q_lambda(),
+    '==': q_lambda(),
+    '===': q_lambda(),
+
+    'less than': q_lambda('lt'),
+    '<': q_lambda('lt'),
+
+    'less than or equal': q_lambda('lte'),
+    '<=': q_lambda('lte'),
+    '=<': q_lambda('lte'),
+
+    'greater than': q_lambda('gt'),
+    '>': q_lambda('gt'),
+
+    'greater than or equal': q_lambda('gte'),
+    '>=': q_lambda('gte'),
+    '=>': q_lambda('gte'),
+
+    'contains': q_lambda('contains'),
+    '::': q_lambda('contains'),
+
+    'matches': q_lambda('regex'),
+    'unicorn': q_lambda('regex'),
+    '@': q_lambda('regex')
 }
 
+COMPOUND_TYPE = 'Compound'
 BIN_TYPE = 'BinaryExpression'
 UN_TYPE = 'UnaryExpression'
 IDENTITY_TYPE = 'Identifier'

--- a/api/test_tl_filter.py
+++ b/api/test_tl_filter.py
@@ -196,7 +196,7 @@ class BuilderTestCase(QTestCase):
                     'operator': '=='
                 },
                 "type": "EVAL"
-        })
+            })
 
     def test_binary_missing_left(self):
         with self.assertRaisesMessage(ValueError,

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -2,5 +2,6 @@ from django.conf import urls
 from django.views import generic as generic_views
 
 urlpatterns = [
-    urls.url(r'^$', generic_views.TemplateView.as_view(template_name="portal/home.html"))
+    urls.url(r'^$', generic_views.TemplateView.as_view(
+        template_name="portal/home.html"))
 ]

--- a/widgets/admin.py
+++ b/widgets/admin.py
@@ -1,3 +1,3 @@
-from django.contrib import admin
-
-# Register your models here.
+# from django.contrib import admin
+#
+# # Register your models here.

--- a/widgets/models.py
+++ b/widgets/models.py
@@ -2,7 +2,12 @@ from django.db import models
 from oauth2_provider import models as oauth_models
 from django import conf
 
+
 # Create your models here.
+
+class WidgetType(models.Model):
+    """A type of widget, for example a clock or simple notepad"""
+    owner = models.ForeignKey(oauth_models.Application)
 
 
 class WidgetVersion(models.Model):
@@ -24,11 +29,6 @@ class WidgetVersion(models.Model):
 
     # Governs the availability of this version to end users
     active = models.BooleanField(default=False)
-
-
-class WidgetType(models.Model):
-    """A type of widget, for example a clock or simple notepad"""
-    owner = models.ForeignKey(oauth_models.Application)
 
 
 class Widget(models.Model):

--- a/widgets/tests.py
+++ b/widgets/tests.py
@@ -1,3 +1,3 @@
-from django.test import TestCase
-
-# Create your tests here.
+# from django.test import TestCase
+#
+# # Create your tests here.

--- a/widgets/views.py
+++ b/widgets/views.py
@@ -1,3 +1,3 @@
-from django.shortcuts import render
-
-# Create your views here.
+# from django.shortcuts import render
+#
+# # Create your views here.


### PR DESCRIPTION
Add and implement a lot more operators in the query language so that you can ask queries in a style like

```
year:17 and (major:Mathematics or major:"Computer Science")
```

and they evaluate properly. Most operators come from Jay (the voting system). 

/cc @kuboschek and thanks for some of the implementation