### PR TITLE
Add PEP8 testing to travis tests (fixes #42)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ install:
   - pip install -r requirements.txt
 
 script:
+  - python check_pep8.py
   - python manage.py test

--- a/check_pep8.py
+++ b/check_pep8.py
@@ -1,5 +1,35 @@
-#!/usr/bin/env python
-import subprocess
+import os
+import unittest
 
-subprocess.call(['flake8', '--exclude',
-                 'env, dreamjub/migrations, login/migrations', '.'])
+import pep8
+
+ignore_patterns = ('env', '.git', '__pycache__', 'dreamjub/migrations')
+
+
+def _ignore(directory: str) -> bool:
+    """Should the directory be ignored?"""
+
+    for pattern in ignore_patterns:
+        if pattern in directory:
+            return True
+    return False
+
+
+class SanityTest(unittest.TestCase):
+    """Run PEP8 on all files in this directory and subdirectories."""
+
+    def test_pep8_compliance(self):
+        style = pep8.StyleGuide(quiet=False)
+        errors = 0
+        for root, _, files in os.walk('.'):
+            if _ignore(root):
+                continue
+            python_files = [os.path.join(root, f) for f in files if
+                            f.endswith('.py')]
+            errors += style.check_files(python_files).total_errors
+
+        self.assertEqual(errors, 0, 'PEP8 style errors: {}'.format(errors))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/check_pep8.py
+++ b/check_pep8.py
@@ -3,7 +3,9 @@ import unittest
 
 import pep8
 
-ignore_patterns = ('env', '.git', '__pycache__', 'dreamjub/migrations')
+ignore_patterns = (
+    'env', '.git', '__pycache__', 'dreamjub/migrations', 'login/migrations',
+    'portal/migrations', 'widgets/migrations')
 
 
 def _ignore(directory: str) -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,6 @@ django-filter>=0.15.3
 
 # For the extended filter language
 pre-js-py==1.1.0
+
+# For testing pep
+pep8 >= 1.7.0


### PR DESCRIPTION
Recently a lot of commits and PRs have been breaking PEP8 compliance. This PR reworks and adds PEP8 style checking to travis tests to prevent this in the future. In particular the check_pep8.py script has been turned into a proper unittest TestCase. 

/cc @thunderboltsid 