### PR TITLE
Update OAuth Provider Class Location

### DIFF
--- a/dreamjub/settings.py
+++ b/dreamjub/settings.py
@@ -136,7 +136,7 @@ OAUTH2_PROVIDER = {
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'oauth2_provider.ext.rest_framework.OAuth2Authentication',
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
         'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (


### PR DESCRIPTION
A recent update to django-oauth-toolkit amongst other things moved the
Django OAuth Provider Classes from ext.rest_framework to
contrib.rest_framework. This caused an exception when running dreamjub
with the newest version of oauth-toolkit.

This PR fixes the problem by updating settings.py to use the
provider from the new source instead.