### PR TITLE
Fallback to building when parsing college

### DIFF
--- a/jacobsdata/parsing/user_components/college.py
+++ b/jacobsdata/parsing/user_components/college.py
@@ -1,4 +1,5 @@
 from . import component
+from jacobsdata.parsing.user_components.buildings import rooms
 
 college_map = {
     'Alfried Krupp College': 'Krupp',
@@ -8,11 +9,14 @@ college_map = {
     '': ''
 }
 
+college_choices = [college_map[k] for k in college_map]
+
 
 class CollegeComponent(component.UserParsingComponent):
     """ Represents the college of a user. """
 
-    fields = ['houseIdentifier']
+    fields = ['houseIdentifier', 'telephoneNumber',
+              'physicalDeliveryOfficeName']
 
     def parse(self, user: dict) -> dict:
 
@@ -26,6 +30,32 @@ class CollegeComponent(component.UserParsingComponent):
             print("Warning: 'house_identifier' has unknown value: %r" % (
                 house_identifier))
             college = ''
+
+        # fallack to parsing from the building
+        if college == '':
+            # check if we have the phone
+            phone = self.get_attribute(user, 'telephoneNumber', '')
+            room = self.get_attribute(user, 'room', '')
+
+            # Booleans indicating if we have room and phone number
+            hasPhone = phone != ''
+            hasRoom = room != ''
+
+            building = ''
+
+            if hasPhone:
+                room_obj = rooms.get_room_by_phone(phone)
+
+                if room_obj is not None:
+                    building = room_obj["building"]
+
+            elif hasRoom and not hasPhone:
+                room_obj = rooms.get_room_by_room(room)
+                if room_obj is not None:
+                    building = room_obj["building"]
+
+            if building in college_choices:
+                college = building
 
         return {
             'college': college


### PR DESCRIPTION
By default, student data retrieves the college information from the houseIdentifier field. This meant when that field was missing, no college information was available.

This PR updates the parsing module to fallback to getting the college via the building field, if this applies.

/cc @kuboschek 