### PR TITLE
Make 'contains' operator case-insensitive

### DIFF
--- a/api/filters/operators.py
+++ b/api/filters/operators.py
@@ -70,8 +70,8 @@ BIN_OPS = {
     '>=': q_lambda('gte'),
     '=>': q_lambda('gte'),
 
-    'contains': q_lambda('contains'),
-    '::': q_lambda('contains'),
+    'contains': q_lambda('icontains'),
+    '::': q_lambda('icontains'),
 
     'matches': q_lambda('regex'),
     'unicorn': q_lambda('regex'),


### PR DESCRIPTION
Previously, the contains operator for the 'tl' users end point was case sensitive, making it difficult to search for names without paying specific attention to the case.

This PR updates the operator case insensitive, to enabling easier searching for strings within names, both at the beginning and in the middle of the name.

/cc @kuboschek 